### PR TITLE
Fix panic error when no timeseries exist for available metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,39 +72,42 @@ func (c *Collector) extractMetrics(ch chan<- prometheus.Metric, rm resourceMeta,
 		metricName = strings.ToLower(metricName + "_" + value.Unit)
 		metricName = strings.Replace(metricName, "/", "_per_", -1)
 		metricName = invalidMetricChars.ReplaceAllString(metricName, "_")
-		metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]
-		labels := CreateResourceLabels(rm.resourceURL)
 
-		if hasAggregation(rm.aggregations, "Total") {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Total,
-			)
-		}
+		if len(value.Timeseries) > 0 {
+			metricValue := value.Timeseries[0].Data[len(value.Timeseries[0].Data)-1]
+			labels := CreateResourceLabels(rm.resourceURL)
 
-		if hasAggregation(rm.aggregations, "Average") {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Average,
-			)
-		}
+			if hasAggregation(rm.aggregations, "Total") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_total", metricName+"_total", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Total,
+				)
+			}
 
-		if hasAggregation(rm.aggregations, "Minimum") {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Minimum,
-			)
-		}
+			if hasAggregation(rm.aggregations, "Average") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_average", metricName+"_average", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Average,
+				)
+			}
 
-		if hasAggregation(rm.aggregations, "Maximum") {
-			ch <- prometheus.MustNewConstMetric(
-				prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
-				prometheus.GaugeValue,
-				metricValue.Maximum,
-			)
+			if hasAggregation(rm.aggregations, "Minimum") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_min", metricName+"_min", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Minimum,
+				)
+			}
+
+			if hasAggregation(rm.aggregations, "Maximum") {
+				ch <- prometheus.MustNewConstMetric(
+					prometheus.NewDesc(metricName+"_max", metricName+"_max", nil, labels),
+					prometheus.GaugeValue,
+					metricValue.Maximum,
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixing this kind of error if a metric is available for a type, but has not timeseries:

```
panic: runtime error: index out of range

goroutine 33 [running]:
main.(*Collector).extractMetrics(0xda6398, 0xc0003c20c0, 0xc00022f353, 0x56, 0xc00061e000, 0x195, 0xc0002fc0f0, 0x4c, 0xc00006f2c0, 0x4, ...)
        /home/louisfelix/workspace/go/src/github.com/RobustPerception/azure_metrics_exporter/main.go:75 +0xf3c
main.(*Collector).batchCollectMetrics(0xda6398, 0xc0003c20c0, 0xc0000c86e0, 0x2, 0x2)
        /home/louisfelix/workspace/go/src/github.com/RobustPerception/azure_metrics_exporter/main.go:153 +0x470
main.(*Collector).Collect(0xda6398, 0xc0003c20c0)
        /home/louisfelix/workspace/go/src/github.com/RobustPerception/azure_metrics_exporter/main.go:291 +0xb8f
github.com/RobustPerception/azure_metrics_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /home/louisfelix/workspace/go/src/github.com/RobustPerception/azure_metrics_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:442 +0x19d
created by github.com/RobustPerception/azure_metrics_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        /home/louisfelix/workspace/go/src/github.com/RobustPerception/azure_metrics_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:453 +0x56e
```